### PR TITLE
修复了在3.10以上版本Python运行报错 As of 3.10, the *loop* parameter was removed f…

### DIFF
--- a/cdr/aio/tasks.py
+++ b/cdr/aio/tasks.py
@@ -10,8 +10,10 @@ import asyncio
 class Tasks:
 
     def __init__(self, max_async, loop=None):
-        self.loop = loop or asyncio.get_event_loop()
-        self._queue = asyncio.Queue(maxsize=100, loop=self.loop)
+        #self.loop = loop or asyncio.get_event_loop()
+        self.loop = asyncio.get_event_loop()
+        #self._queue = asyncio.Queue(maxsize=100, loop=self.loop)
+        self._queue = asyncio.Queue(maxsize=100) #3.10之后的Python不需要loop参数
         self.max_async = max_async
         self.work_list = []
 


### PR DESCRIPTION
…rom Queue() since it is no longer necessary的问题

修复了在3.10以上版本Python运行报错 As of 3.10, the *loop* parameter was removed from Queue() since it is no longer necessary的问题